### PR TITLE
[iOS] Fix subtitle track duration

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -458,7 +458,7 @@ static int const RCTVideoUnset = -1;
     AVMutableCompositionTrack *textCompTrack = [mixComposition
                                                 addMutableTrackWithMediaType:AVMediaTypeText
                                                 preferredTrackID:kCMPersistentTrackID_Invalid];
-    [textCompTrack insertTimeRange:CMTimeRangeMake(kCMTimeZero, videoAsset.timeRange.duration)
+    [textCompTrack insertTimeRange:CMTimeRangeMake(kCMTimeZero, textTrackAsset.timeRange.duration)
                            ofTrack:textTrackAsset
                             atTime:kCMTimeZero
                              error:nil];


### PR DESCRIPTION
On iOS the subtitle's weren't hiding because it was using the length of the video, now it'll use the length of the subtitle track